### PR TITLE
Convert byte segment into integer array

### DIFF
--- a/ios/VCZBarCodeScanner.m
+++ b/ios/VCZBarCodeScanner.m
@@ -116,10 +116,25 @@ static inline id convertZXResultPoint(ZXResultPoint *point) {
 }
 
 // To Base64
+/**
+ * Converts a `ZXByteArray` object to React Native compatible object.
+ *
+ * This function converts a `ZXByteArray` object to an array containing
+ * integers.
+ */
 static id convertZXByteArray(ZXByteArray *byteSegment) {
-  NSData *data = [NSData dataWithBytes:byteSegment.array
-                                length:byteSegment.length * sizeof(int8_t)];
-  return [data base64EncodedStringWithOptions:0];
+  // Basically, most application converts raw bytes into base64 string,
+  // but we converts it to an array containing integers.
+  // We chose this approach because a byte segment is relatively small
+  // in the most cases.
+  NSMutableArray *bytes =
+      [[NSMutableArray alloc] initWithCapacity:byteSegment.length];
+
+  for (int i = 0; i < byteSegment.length; i++) {
+    [bytes addObject:@(byteSegment.array[i])];
+  }
+
+  return bytes;
 }
 
 // QRCode metadata value to React native value.


### PR DESCRIPTION
Basically, most application converts raw bytes into base64 string, but we converts it to an array containing integers. We chose this approach because a byte segment is relatively small in the most cases.

```
2022-06-09 14:02:54.315441+0900 ExampleApp[71674:3889716] [javascript] 'value =', { format: 11,
  points: 
   [ { x: 1161.5, y: 626 },
     { x: 870, y: 622.5 },
     { x: 872.5, y: 328 },
     { x: 1117.5, y: 380.5 } ],
  metadata: 
   { ErrorCorrectionLevel: 'L',
     ByteSegments: 
      [ [ 104,
          116,
          116,
          112,
          115,
          58,
          47,
          47,
          106,
          97,
          46,
          119,
          105,
          107,
          105,
          112,
          101,
          100,
          105,
          97,
          46,
          111,
          114,
          103,
          47 ] ] },
  text: 'https://ja.wikipedia.org/' }
```